### PR TITLE
Add CLI help and test commands and improve turtle canvas sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,26 @@ uv run python dessins.py dragon
 ## Usage
 Basic usage:
 ```sh
-python dessins.py <command> <shape_name|design_number>
+python dessins.py <command> [<shape_name|design_number>]
 ```
-where `command` is `shape|design`. After that, the user provides a `shape_name` (if `shape` was selected). If `design` was provided by the user, the `design_number` needs to be selected.
-This will run the standard program from the book.
+where `command` is `shape`, `design`, `help`, or `test`.
+
+* `shape` – draw a specific shape. Provide a `shape_name`.
+* `design` – draw a design from the book. Provide a `design_number`.
+* `help` – list available shapes and designs.
+* `test` – render every design sequentially with a 0.5-second pause between each.
+
 The plotting window `NP` is generally set at `480`.
+
+List all available shapes and designs:
+```sh
+python dessins.py help
+```
+
+Run every design sequentially:
+```sh
+python dessins.py test
+```
 
 Generate a shape:
 ```sh

--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ where `command` is `shape`, `design`, `help`, or `test`.
 
 * `shape` – draw a specific shape. Provide a `shape_name`.
 * `design` – draw a design from the book. Provide a `design_number`.
-* `help` – list available shapes and designs.
+* `help` – list available commands, shapes, and designs.
 * `test` – render every design sequentially with a 0.5-second pause between each.
 
 The plotting window `NP` is generally set at `480`.
 
-List all available shapes and designs:
+List all available commands, shapes, and designs:
 ```sh
 python dessins.py help
 ```

--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ List all available commands, shapes, and designs:
 python dessins.py help
 ```
 
+List all available shapes:
+```sh
+python dessins.py shape help
+```
+
+See parameters for a specific shape:
+```sh
+python dessins.py <shape_name> help
+```
+
 Run every design sequentially:
 ```sh
 python dessins.py test

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ where `command` is `shape`, `design`, `help`, or `test`.
 * `shape` – draw a specific shape. Provide a `shape_name`.
 * `design` – draw a design from the book. Provide a `design_number`.
 * `help` – list available commands, shapes, and designs.
-* `test` – render every design sequentially with a 0.5-second pause between each.
+* `test` – render designs in 4×4 batches with a 0.5-second pause between drawings.
 
 The plotting window `NP` is generally set at `480`.
 
@@ -108,7 +108,7 @@ See parameters for a specific shape:
 python dessins.py <shape_name> help
 ```
 
-Run every design sequentially:
+Run every design in 4×4 batches:
 ```sh
 python dessins.py test
 ```

--- a/designs/__init__.py
+++ b/designs/__init__.py
@@ -1,4 +1,8 @@
-from cad import capture_points
+try:
+    from cad import capture_points
+except Exception:  # pragma: no cover - CAD optional
+    def capture_points(func):
+        return func
 
 from .polygons_stars import (
     design_1,

--- a/dessins.py
+++ b/dessins.py
@@ -16,7 +16,7 @@ def setup_canvas(command: str, width: int, height: int, animation: str = "instan
     """Configure the turtle canvas for a given command."""
     size = min(width, height)
     turtle.setup(width=width, height=height)
-    turtle.screensize(width=width, height=height)
+    turtle.screensize(canvwidth=width, canvheight=height)
 
     if command.startswith("design_"):
         design_num = int(command.split("_")[1])
@@ -197,6 +197,12 @@ def main() -> int:
     size = min(width, height)
 
     if args.command == "help":
+        print("Commands:")
+        print("  shape <shape_name> [options]   Draw a predefined shape")
+        print("  design <number> [options]      Draw a predefined design")
+        print("  test [options]                 Render every design sequentially")
+        print("  help                           Show this help message\n")
+
         print("Available shapes:")
         for name in sorted(get_available_shapes()):
             print(f" - {name}")

--- a/dessins.py
+++ b/dessins.py
@@ -111,6 +111,37 @@ def get_available_designs() -> list[str]:
     return designs_list
 
 
+def print_shape_help(shape_name: str) -> None:
+    """Display available parameters for a given shape."""
+    shapes_module = importlib.import_module("shapes")
+    func_name = f"draw_{shape_name}"
+    try:
+        draw_func = getattr(shapes_module, func_name)
+    except AttributeError:
+        print(f"Error: Shape '{shape_name}' not found.")
+        return
+
+    sig = inspect.signature(draw_func)
+    doc = inspect.getdoc(draw_func) or ""
+
+    print(f"Parameters for shape '{shape_name}':")
+    if doc:
+        print(doc)
+
+    if not sig.parameters:
+        print("  (no parameters)")
+        return
+
+    for name, param in sig.parameters.items():
+        if param.kind in {inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD}:
+            continue
+        if param.default is inspect._empty:
+            default = "required"
+        else:
+            default = f"default={param.default!r}"
+        print(f"  {name}: {default}")
+
+
 def initialize_parsers() -> argparse.ArgumentParser:
     """Create the command-line argument parser."""
     parser = argparse.ArgumentParser(description="Draw shapes and designs using Turtle graphics.")
@@ -179,6 +210,23 @@ def initialize_parsers() -> argparse.ArgumentParser:
 
 def main() -> int:
     """Program entry point."""
+    args_list = sys.argv[1:]
+    available_shapes = set(get_available_shapes())
+
+    if args_list:
+        if args_list[0] == "shape":
+            if len(args_list) == 1 or args_list[1] == "help":
+                print("Available shapes:")
+                for name in sorted(available_shapes):
+                    print(f" - {name}")
+                return 0
+            if args_list[-1] == "help" and args_list[1] in available_shapes:
+                print_shape_help(args_list[1])
+                return 0
+        elif args_list[-1] == "help" and args_list[0] in available_shapes:
+            print_shape_help(args_list[0])
+            return 0
+
     parser = initialize_parsers()
     args = parser.parse_args()
 
@@ -196,9 +244,8 @@ def main() -> int:
         print("Available shapes:")
         for name in sorted(get_available_shapes()):
             print(f" - {name}")
-        print("\nAvailable designs:")
-        for name in sorted(get_available_designs(), key=int):
-            print(f" - {name}")
+        designs = get_available_designs()
+        print(f"\nAvailable designs: 1 to {len(designs)}")
         return 0
     elif args.command == "shape":
         shape_name = args.shape_name

--- a/dessins.py
+++ b/dessins.py
@@ -27,6 +27,7 @@ def setup_canvas(command: str, width: int, height: int, animation: str = "instan
 
     turtle.penup()
     turtle.home()
+    turtle.pendown()
     turtle.hideturtle()
 
 
@@ -36,14 +37,30 @@ def draw_shape(draw_function: Callable[..., T], *args: Any, **kwargs: Any) -> T:
 
 
 def fit_canvas_to_points(points: list[tuple[float, float]] | None) -> None:
-    """Resize and center the canvas around the drawn points."""
-    if not points:
-        return
+    """Resize and center the canvas around the drawn points.
 
-    xs = [x for x, _ in points]
-    ys = [y for _, y in points]
-    min_x, max_x = min(xs), max(xs)
-    min_y, max_y = min(ys), max(ys)
+    If ``points`` is ``None`` the bounding box is derived from the Tkinter
+    canvas, allowing shapes that don't return point lists to be fitted.
+    """
+
+    if points:
+        xs = [x for x, _ in points]
+        ys = [y for _, y in points]
+        min_x, max_x = min(xs), max(xs)
+        min_y, max_y = min(ys), max(ys)
+    else:
+        canvas = turtle.getcanvas()
+        bbox = canvas.bbox("all")
+        if not bbox:
+            return
+        min_cx, min_cy, max_cx, max_cy = bbox
+
+        width = turtle.window_width()
+        height = turtle.window_height()
+        min_x = min_cx - width / 2
+        max_x = max_cx - width / 2
+        min_y = height / 2 - max_cy
+        max_y = height / 2 - min_cy
 
     pad_x = (max_x - min_x) * 0.05 or 10
     pad_y = (max_y - min_y) * 0.05 or 10
@@ -212,6 +229,8 @@ def main() -> int:
     """Program entry point."""
     args_list = sys.argv[1:]
     available_shapes = set(get_available_shapes())
+    output_name: str | None = None
+    pts: list[tuple[float, float]] | None = None
 
     if args_list:
         if args_list[0] == "shape":
@@ -275,6 +294,7 @@ def main() -> int:
         output_name = args.output if hasattr(args, "output") else None
         pts = draw_shape(draw_function, **draw_args)
         fit_canvas_to_points(pts)
+        turtle.update()
 
     elif args.command == "design":
         design_number = args.design_number
@@ -299,10 +319,11 @@ def main() -> int:
         output_name = args.output if hasattr(args, "output") else None
         pts = draw_shape(draw_function, **draw_args)
         fit_canvas_to_points(pts)
+        turtle.update()
     elif args.command == "test":
         animation = args.animation if hasattr(args, "animation") else "instant"
         test_everything(width=width, height=height, animation=animation)
-        pts = None
+        return 0
     else:
         print(f"Error: Unknown command '{args.command}'.")
         return 1
@@ -340,6 +361,7 @@ def test_everything(width: int = 480, height: int = 480, animation: str = "insta
 
         # Reset after each design to avoid overlap
         turtle.reset()
+        turtle.hideturtle()
 
         # Every 16 designs, clear the screen completely
         if index % 16 == 0:

--- a/dessins.py
+++ b/dessins.py
@@ -97,16 +97,283 @@ def get_shape_args() -> dict[str, dict[str, Any]]:
             "args": {
                 "-K": {"type": int, "default": 5, "required": False, "help": "Number of sides"},
                 "-R": {"type": float, "default": 240 * 0.45, "required": False, "help": "Radius, NP/2*R"},
-                "-AD": {"type": float, "default": math.pi / 4, "required": False, "help": "Starting angle in radians"},
+                "-AD": {
+                    "type": float,
+                    "default": math.pi / 4,
+                    "required": False,
+                    "help": "Starting angle in radians",
+                },
             },
         },
         "regular_star": {
             "help": "Draw a regular star.",
             "args": {
                 "-K": {"type": int, "default": 8, "required": False, "help": "Number of points"},
-                "-H": {"type": int, "default": 3, "required": False, "help": "Skip H points each time"},
+                "-H": {
+                    "type": int,
+                    "default": 3,
+                    "required": False,
+                    "help": "Skip H points each time",
+                },
                 "-R": {"type": float, "default": 130, "required": False, "help": "Radius"},
-                "-AD": {"type": float, "default": math.pi / 2, "required": False, "help": "Starting angle in radians"},
+                "-AD": {
+                    "type": float,
+                    "default": math.pi / 2,
+                    "required": False,
+                    "help": "Starting angle in radians",
+                },
+            },
+        },
+        "bird_fish": {
+            "help": "Draw the bird-fish curve.",
+            "args": {
+                "-NP": {
+                    "type": int,
+                    "default": 480,
+                    "required": False,
+                    "help": "Canvas scale",
+                }
+            },
+        },
+        "complete_bipartite_graph": {
+            "help": "Draw a complete bipartite graph.",
+            "args": {
+                "-N": {"type": int, "default": 10, "required": False, "help": "Points per set"},
+                "-XA": {"type": int, "default": 0, "required": False, "help": "XA"},
+                "-YA": {"type": int, "default": 0, "required": False, "help": "YA"},
+                "-XB": {"type": int, "default": 0, "required": False, "help": "XB"},
+                "-YB": {"type": int, "default": 480, "required": False, "help": "YB"},
+                "-XC": {"type": int, "default": 480, "required": False, "help": "XC"},
+                "-YC": {"type": int, "default": 0, "required": False, "help": "YC"},
+                "-XD": {"type": int, "default": 480, "required": False, "help": "XD"},
+                "-YD": {"type": int, "default": 480, "required": False, "help": "YD"},
+                "-NP": {"type": int, "default": 480, "required": False, "help": "Canvas scale"},
+            },
+        },
+        "composition_1": {
+            "help": "Draw composition 1.",
+            "args": {
+                "-K1": {"type": int, "default": 5, "required": False, "help": "Inner polygon sides"},
+                "-DX": {"type": float, "default": 240, "required": False, "help": "Center X"},
+                "-DY": {"type": float, "default": 240, "required": False, "help": "Center Y"},
+                "-R1": {
+                    "type": float,
+                    "default": 240 * 0.54,
+                    "required": False,
+                    "help": "Inner radius",
+                },
+                "-A1": {
+                    "type": float,
+                    "default": math.pi / 2,
+                    "required": False,
+                    "help": "Inner angle",
+                },
+                "-K": {"type": int, "default": 25, "required": False, "help": "Star points"},
+                "-H": {"type": int, "default": 12, "required": False, "help": "Skip points"},
+                "-R": {
+                    "type": float,
+                    "default": 240 * 0.44,
+                    "required": False,
+                    "help": "Outer radius",
+                },
+                "-AD": {
+                    "type": float,
+                    "default": math.pi / 2,
+                    "required": False,
+                    "help": "Starting angle",
+                },
+                "-NP": {"type": int, "default": 480, "required": False, "help": "Canvas scale"},
+            },
+        },
+        "composition_2": {
+            "help": "Draw composition 2.",
+            "args": {
+                "-K1": {"type": int, "default": 8, "required": False, "help": "Inner polygon sides"},
+                "-N": {"type": int, "default": 32, "required": False, "help": "Points"},
+                "-K": {"type": int, "default": 16, "required": False, "help": "Star points"},
+                "-H": {"type": int, "default": 5, "required": False, "help": "Skip points"},
+                "-R1": {"type": float, "default": 240 * 0.72, "required": False, "help": "Inner radius"},
+                "-R": {"type": float, "default": 240 * 0.28, "required": False, "help": "Outer radius"},
+                "-RR": {"type": float, "default": 0.9, "required": False, "help": "Radius ratio"},
+                "-DX": {"type": float, "default": 240, "required": False, "help": "Center X"},
+                "-DY": {"type": float, "default": 240, "required": False, "help": "Center Y"},
+                "-NP": {"type": int, "default": 480, "required": False, "help": "Canvas scale"},
+            },
+        },
+        "d3cube": {"help": "Draw a 3D cube.", "args": {}},
+        "d3data": {
+            "help": "Draw 3D data.",
+            "args": {
+                "-DC": {"type": int, "default": 2, "required": False, "help": "Data columns"},
+                "-TC": {"type": int, "default": 2, "required": False, "help": "Time columns"},
+                "-NP": {"type": int, "default": 480, "required": False, "help": "Canvas scale"},
+            },
+        },
+        "d3structures": {"help": "Draw 3D structures.", "args": {}},
+        "dragon": {
+            "help": "Draw a paper-folding dragon.",
+            "args": {
+                "-N": {"type": int, "default": 10, "required": False, "help": "Iterations"},
+                "-NP": {"type": int, "default": 480, "required": False, "help": "Canvas scale"},
+            },
+        },
+        "elastic_grid": {
+            "help": "Draw an elastic grid.",
+            "args": {
+                "-L_RANGE": {"type": int, "default": 2, "required": False, "help": "L range"},
+                "-I_RANGE": {"type": int, "default": 21, "required": False, "help": "I range"},
+                "-J_RANGE": {"type": int, "default": 21, "required": False, "help": "J range"},
+                "-NP": {"type": int, "default": 480, "required": False, "help": "Canvas scale"},
+            },
+        },
+        "fractal_star": {
+            "help": "Draw a fractal star.",
+            "args": {
+                "-N": {"type": int, "default": 5, "required": False, "help": "Branches"},
+                "-K": {"type": int, "default": 5, "required": False, "help": "Levels"},
+                "-RA": {"type": float, "default": 0.35, "required": False, "help": "Ratio"},
+                "-LL": {"type": int, "default": None, "required": False, "help": "Initial length"},
+                "-AA": {
+                    "type": float,
+                    "default": 4 * math.pi / 5,
+                    "required": False,
+                    "help": "Angle increment",
+                },
+                "-NP": {"type": int, "default": 480, "required": False, "help": "Canvas scale"},
+            },
+        },
+        "horse": {
+            "help": "Draw a horse from data.",
+            "args": {
+                "-NP": {"type": int, "default": 480, "required": False, "help": "Canvas scale"}
+            },
+        },
+        "linear_modulo": {
+            "help": "Draw linear modulo patterns.",
+            "args": {
+                "-N": {"type": int, "default": 400, "required": False, "help": "Points"},
+                "-M": {"type": int, "default": 400, "required": False, "help": "Modulo"},
+                "-K1": {"type": float, "default": 4, "required": False, "help": "K1"},
+                "-K2": {"type": float, "default": 5, "required": False, "help": "K2"},
+                "-H": {"type": int, "default": 2, "required": False, "help": "H"},
+                "-NP": {"type": int, "default": 480, "required": False, "help": "Canvas scale"},
+            },
+        },
+        "linear_sticks": {
+            "help": "Draw linear sticks patterns.",
+            "args": {
+                "-N": {"type": int, "default": 100, "required": False, "help": "Number of sticks"},
+                "-M": {"type": int, "default": 1, "required": False, "help": "M"},
+                "-K": {"type": int, "default": 5, "required": False, "help": "K"},
+                "-NP": {"type": int, "default": 480, "required": False, "help": "Canvas scale"},
+            },
+        },
+        "lion": {
+            "help": "Draw a lion from data.",
+            "args": {
+                "-NP": {"type": int, "default": 480, "required": False, "help": "Canvas scale"}
+            },
+        },
+        "orbiting_curves": {
+            "help": "Draw orbiting curves.",
+            "args": {
+                "-N": {"type": int, "default": 2000, "required": False, "help": "Iterations"},
+                "-T1": {"type": int, "default": 2, "required": False, "help": "T1"},
+                "-T2": {"type": int, "default": 100, "required": False, "help": "T2"},
+                "-K1": {"type": int, "default": 1, "required": False, "help": "K1"},
+                "-K2": {"type": int, "default": 1, "required": False, "help": "K2"},
+                "-R1": {"type": float, "default": 120.0, "required": False, "help": "Radius"},
+                "-NP": {"type": int, "default": 480, "required": False, "help": "Canvas scale"},
+            },
+        },
+        "prettygon": {
+            "help": "Draw a prettygon.",
+            "args": {
+                "-K": {"type": int, "default": 200, "required": False, "help": "Iterations"},
+                "-AN": {
+                    "type": float,
+                    "default": 1.5201254775434483,
+                    "required": False,
+                    "help": "Angle",
+                },
+                "-RA": {"type": float, "default": 0.98, "required": False, "help": "Radius ratio"},
+                "-AA": {"type": float, "default": 0.0, "required": False, "help": "Angle adjust"},
+                "-RR": {"type": float, "default": 384.0, "required": False, "help": "Radius"},
+                "-INITIAL_Y": {
+                    "type": float,
+                    "default": 0,
+                    "required": False,
+                    "help": "Initial Y position",
+                },
+                "-NP": {"type": int, "default": 480, "required": False, "help": "Canvas scale"},
+            },
+        },
+        "rotating_curves": {
+            "help": "Draw rotating curves.",
+            "args": {
+                "-N": {"type": int, "default": 2000, "required": False, "help": "Iterations"},
+                "-T1": {"type": int, "default": 1, "required": False, "help": "T1"},
+                "-T2": {"type": int, "default": 100, "required": False, "help": "T2"},
+                "-K1": {"type": int, "default": 1, "required": False, "help": "K1"},
+                "-K2": {"type": int, "default": 1, "required": False, "help": "K2"},
+                "-H1": {"type": int, "default": 1, "required": False, "help": "H1"},
+                "-H2": {"type": int, "default": 1, "required": False, "help": "H2"},
+                "-R1": {"type": float, "default": 80.0, "required": False, "help": "Radius 1"},
+                "-R2": {"type": float, "default": 120.0, "required": False, "help": "Radius 2"},
+                "-NP": {"type": int, "default": 480, "required": False, "help": "Canvas scale"},
+            },
+        },
+        "simple_fractal": {
+            "help": "Draw a simple fractal.",
+            "args": {
+                "-M": {"type": int, "default": 3, "required": False, "help": "M"},
+                "-N": {"type": int, "default": 4, "required": False, "help": "N"},
+                "-K": {"type": int, "default": 4, "required": False, "help": "K"},
+            },
+        },
+        "simple_fractal_deformed": {
+            "help": "Draw a deformed simple fractal.",
+            "args": {
+                "-M": {"type": int, "default": 3, "required": False, "help": "M"},
+                "-N": {"type": int, "default": 4, "required": False, "help": "N"},
+                "-K": {"type": int, "default": 4, "required": False, "help": "K"},
+                "-NP": {"type": int, "default": 480, "required": False, "help": "Canvas scale"},
+            },
+        },
+        "simple_fractal_rounded": {
+            "help": "Draw a rounded simple fractal.",
+            "args": {
+                "-M": {"type": int, "default": 1, "required": False, "help": "M"},
+                "-N": {"type": int, "default": 7, "required": False, "help": "N"},
+                "-K": {"type": int, "default": 2, "required": False, "help": "K"},
+                "-S": {"type": int, "default": 5, "required": False, "help": "S"},
+            },
+        },
+        "smurf": {
+            "help": "Draw a smurf from data.",
+            "args": {
+                "-NP": {"type": int, "default": 480, "required": False, "help": "Canvas scale"}
+            },
+        },
+        "spiraling_curves": {
+            "help": "Draw spiraling curves.",
+            "args": {
+                "-N": {"type": int, "default": 2000, "required": False, "help": "Iterations"},
+                "-T": {"type": float, "default": 40, "required": False, "help": "T"},
+                "-R": {"type": float, "default": 0.8, "required": False, "help": "Radius"},
+                "-L": {"type": float, "default": 0.1, "required": False, "help": "L"},
+                "-NP": {"type": int, "default": 480, "required": False, "help": "Canvas scale"},
+            },
+        },
+        "surface": {
+            "help": "Draw a surface.",
+            "args": {
+                "-N": {"type": int, "default": 6, "required": False, "help": "Grid size"},
+                "-PA": {"type": float, "default": None, "required": False, "help": "Perspective angle"},
+                "-E1": {"type": int, "default": 2, "required": False, "help": "Exponent 1"},
+                "-E2": {"type": int, "default": 1, "required": False, "help": "Exponent 2"},
+                "-E3": {"type": int, "default": 0, "required": False, "help": "Exponent 3"},
+                "-NP": {"type": int, "default": 480, "required": False, "help": "Canvas scale"},
             },
         },
     }
@@ -257,7 +524,7 @@ def main() -> int:
         print("Commands:")
         print("  shape <shape_name> [options]   Draw a predefined shape")
         print("  design <number> [options]      Draw a predefined design")
-        print("  test [options]                 Render every design sequentially")
+        print("  test [options]                 Render designs in 4x4 batches")
         print("  help                           Show this help message\n")
 
         print("Available shapes:")
@@ -333,39 +600,49 @@ def main() -> int:
 
 
 def test_everything(width: int = 480, height: int = 480, animation: str = "instant") -> None:
-    """Draw every available design sequentially in 4x4 batches.
+    """Draw every available design in 4x4 grid batches.
 
-    Each batch renders 16 designs on the same canvas one after another,
-    resetting the canvas after every group to keep resources in check.
-    A 0.5-second pause is added between designs so each is visible.
+    Sixteen designs are shown at a time. Each design is scaled to fit a
+    cell in the grid and placed so the batch fills the window. A short
+    pause follows each drawing and between batches for visibility.
     """
+
     design_numbers = sorted(int(n) for n in get_available_designs())
-    size = min(width, height)
+    cell_w = width / 4
+    cell_h = height / 4
+    size = min(cell_w, cell_h) * 0.9
 
-    for index, num in enumerate(design_numbers, start=1):
-        command = f"design_{num}"
-        designs_module = importlib.import_module("designs")
-        draw_function = getattr(designs_module, command)
+    for batch_start in range(0, len(design_numbers), 16):
+        setup_canvas("test", width, height, animation)
+        for idx in range(16):
+            if batch_start + idx >= len(design_numbers):
+                break
 
-        setup_canvas(command, width, height, animation)
+            num = design_numbers[batch_start + idx]
+            command = f"design_{num}"
+            designs_module = importlib.import_module("designs")
+            draw_function = getattr(designs_module, command)
 
-        draw_args: dict[str, Any] = {}
-        if "NP" in inspect.signature(draw_function).parameters:
-            draw_args["NP"] = size
+            row, col = divmod(idx, 4)
+            x = -width / 2 + (col + 0.5) * cell_w
+            y = height / 2 - (row + 0.5) * cell_h
 
-        pts = draw_shape(draw_function, **draw_args)
-        fit_canvas_to_points(pts)
-        turtle.update()
+            turtle.penup()
+            turtle.goto(x, y)
+            turtle.setheading(0)
+            turtle.pendown()
+
+            draw_args: dict[str, Any] = {}
+            if "NP" in inspect.signature(draw_function).parameters:
+                draw_args["NP"] = size
+
+            draw_shape(draw_function, **draw_args)
+            turtle.hideturtle()
+            turtle.update()
+            time.sleep(0.5)
 
         time.sleep(0.5)
-
-        # Reset after each design to avoid overlap
-        turtle.reset()
-        turtle.hideturtle()
-
-        # Every 16 designs, clear the screen completely
-        if index % 16 == 0:
-            turtle.clearscreen()
+        turtle.clearscreen()
 
     turtle.bye()
 

--- a/shapes/__init__.py
+++ b/shapes/__init__.py
@@ -1,4 +1,8 @@
-from cad import capture_points
+try:
+    from cad import capture_points
+except Exception:  # pragma: no cover - CAD optional
+    def capture_points(func):
+        return func
 
 from .curves import (
     draw_orbiting_curves,


### PR DESCRIPTION
## Summary
- add `help` CLI subcommand that lists available shapes and designs
- add `test` CLI subcommand that sequentially renders all designs with a 0.5s pause
- ensure turtle canvas fits designs by sizing world coordinates and screen
- make CAD hooks optional to avoid import failures when CAD deps missing

## Testing
- `python -m py_compile dessins.py`
- `python dessins.py help | head -n 20`
- `python dessins.py --help | head -n 20`
- `python dessins.py test --help | head -n 20`
- `python dessins.py test --width 10 --height 10 --animation fast` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6e079a2c832c9e079b9d2491178b